### PR TITLE
Add remapTypes

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,6 +11,7 @@ const { join } = require('path')
 const YAML = require('js-yaml')
 const parseGithubURL = require('parse-github-url')
 const configOverrides = require('./repo-type-mappings')
+const remapTypes = require('./remap.js')
 
 const normaliseConfigType = (type) => {
   return type.replace(/\s/g, '-')
@@ -52,7 +53,8 @@ const injectConfig = (path) => {
       // Throw error here, will be caught and proceed with installConfigDependencies
       throw new Error('No repo.type')
     }
-    const normalisedType = normaliseConfigType(config.type)
+    const normalisedType = remapTypes(normaliseConfigType(config.type))
+    console.error(`Versioning for type: ${normalisedType}`)
     if (configOverrides[normalisedType]) {
       if (config.upstream) {
         config.upstream = extractUpstreamInfo(config.upstream)

--- a/lib/remap.js
+++ b/lib/remap.js
@@ -1,0 +1,16 @@
+const _ = require('lodash')
+const mappings = {
+  'rust-module': [ 'rust-public-crate', 'rust-public-crate-wasm']
+}
+const invertedMappings = {}
+
+Object.keys(mappings).forEach(k => {
+  return mappings[k].forEach(a => invertedMappings[a] = k)
+})
+
+const remapType = (type) => {
+  if (invertedMappings[type]) return invertedMappings[type]
+  return type
+}
+
+module.exports = remapType


### PR DESCRIPTION
This allows us to easier rename existing types and map multiple repo
types to the same versionist settings

Change-type: minor
Signed-off-by: Giovanni Garufi <giovanni@balena.io>