### PR TITLE
Check log level before logging to stderr

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -6,7 +6,11 @@ const balenaVersionist = require('../lib/index.js')
 capitano.command({
   signature: '[path]',
   description: 'Run versionist in path',
-  options: [],
+  options: [{
+    signature: 'silent',
+    boolean: true,
+    description: 'No output, defaults to false'
+  }],
   action: (params, options) => {
     const path = params.path || '.'
     balenaVersionist.runBalenaVersionist(path, options)
@@ -16,7 +20,11 @@ capitano.command({
 capitano.command({
   signature: 'set <version> [path]',
   description: 'Run versionist in path with set versions',
-  options: [],
+  options: [{
+    signature: 'silent',
+    boolean: true,
+    description: 'No output, defaults to false'
+  }],
   action: (params, options) => {
     const path = params.path || '.'
     balenaVersionist.runBalenaVersionist(path, {

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,13 @@ const YAML = require('js-yaml')
 const parseGithubURL = require('parse-github-url')
 const configOverrides = require('./repo-type-mappings')
 const remapTypes = require('./remap.js')
+let LOG_LEVEL = 'verbose'
+
+const log = (l) => {
+  if (LOG_LEVEL !== 'silent') {
+    console.error(l)
+  }
+}
 
 const normaliseConfigType = (type) => {
   return type.replace(/\s/g, '-')
@@ -33,10 +40,11 @@ const extractUpstreamInfo = (upstream) => {
   }]
 }
 
+
 const installConfigDependencies = (path) => {
   return accessAsync(join(path, 'versionist.conf.js'))
   .then(() => {
-    console.error('Installing dev dependencies')
+    log('Installing dev dependencies')
     return execAsync(`npm install --only=dev`, { cwd: path })
     .return(false)
   }).catch((err) => {
@@ -54,15 +62,15 @@ const injectConfig = (path) => {
       throw new Error('No repo.type')
     }
     const normalisedType = remapTypes(normaliseConfigType(config.type))
-    console.error(`Versioning for type: ${normalisedType}`)
+    log(`Versioning for type: ${normalisedType}`)
     if (configOverrides[normalisedType]) {
       if (config.upstream) {
         config.upstream = extractUpstreamInfo(config.upstream)
       }
       return Promise.resolve(configOverrides[normalisedType].getConfig(config))
       .tap((result) => {
-        console.error('Installing injected dependencies')
-        console.error(result.dependencies)
+        log('Installing injected dependencies')
+        log(result.dependencies)
         if (_.isArray(result.dependencies) && !_.isEmpty(result.dependencies)) {
           const dependencies = _.reduce(result.dependencies, (soFar, dep) => {
             soFar += `${dep.name} `
@@ -71,29 +79,32 @@ const injectConfig = (path) => {
           return execAsync(`npm install --no-save ${dependencies}`, { cwd: path })
         }
       }).then((result) => {
-        console.error('Writing temp configuration')
+        log('Writing temp configuration')
         return writeFileAsync(join(path, 'versionist.tmp.js'), result.configuration)
       }).then(() => {
         return true
       })
     }
-    console.error('repo.yml: type does not match a declared preset')
+    log('repo.yml: type does not match a declared preset')
     return false
   })
 }
 
 module.exports.runBalenaVersionist = (path, options = {}) => {
-  console.error('Checking configuration')
+  if (options.silent) {
+    LOG_LEVEL = 'silent'
+  }
+  log('Checking configuration')
   return accessAsync(join(path, 'repo.yml'))
   .then(() => {
     return injectConfig(path)
   })
   .catch((err) => {
     if (err.code === 'ENOENT' || err.message === 'No repo.type') {
-      console.error('No override available')
+      log('No override available')
       return installConfigDependencies(path)
     }
-    console.error(err)
+    log(err)
     throw err
   }).then((injectedConfig) => {
     const extraOpts = buildVersionistOptions(options)
@@ -101,19 +112,19 @@ module.exports.runBalenaVersionist = (path, options = {}) => {
     if (injectedConfig) {
       config += '--config=versionist.tmp.js'
     }
-    console.error('Versioning')
+    log('Versioning')
     return execAsync(`versionist ${config} ${extraOpts}`, { cwd: path })
     .then((stdout, stderr) => {
       logInDebug(`stdout: ${stdout}`)
       logInDebug(`stderr: ${stderr}`)
       return execAsync(`versionist ${config} get version`, { cwd: path })
       .then((stdout, stderr) => {
-        console.error('Built version', stdout)
+        log('Built version', stdout)
         return stdout.trim()
       })
     }).finally(() => {
       if (injectedConfig) {
-        console.error('Deleting temp configuration')
+        log('Deleting temp configuration')
         return unlinkAsync(join(path, 'versionist.tmp.js'))
       }
     })


### PR DESCRIPTION
It is useful to disable stderr logging when running tests as it may cause
issues for some testing frameworks

Change-type: patch
Signed-off-by: Giovanni Garufi <giovanni@balena.io>