### PR TITLE
Update clean function for balena-engine so it removes the v prefix.

### DIFF
--- a/lib/repo-type-mappings/balena-engine/versionist.conf.js
+++ b/lib/repo-type-mappings/balena-engine/versionist.conf.js
@@ -21,7 +21,7 @@ module.exports = {
 
   getChangelogDocumentedVersions: {
     preset: 'changelog-headers',
-    clean: false
+    clean: /v/
   },
 
   getIncrementLevelFromCommit: (commit) => {


### PR DESCRIPTION
We can not use the default (clean: true) as that will run through
semver.isValid, that strips leading 0s from the version numbers

Change-type: patch
Signed-off-by: Giovanni Garufi <giovanni@balena.io>