### PR TITLE
Allow setting a custom versionist configuration

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -54,39 +54,46 @@ const installConfigDependencies = (path) => {
 }
 
 const injectConfig = (path) => {
-  return readFileAsync(join(path, 'repo.yml'), 'utf8')
-  .then((configFile) => {
-    const config = YAML.safeLoad(configFile)
-    if (!config.type) {
-      // Throw error here, will be caught and proceed with installConfigDependencies
-      throw new Error('No repo.type')
-    }
-    const normalisedType = remapTypes(normaliseConfigType(config.type))
-    log(`Versioning for type: ${normalisedType}`)
-    if (configOverrides[normalisedType]) {
-      if (config.upstream) {
-        config.upstream = extractUpstreamInfo(config.upstream)
-      }
-      return Promise.resolve(configOverrides[normalisedType].getConfig(config))
-      .tap((result) => {
-        log('Installing injected dependencies')
-        log(result.dependencies)
-        if (_.isArray(result.dependencies) && !_.isEmpty(result.dependencies)) {
-          const dependencies = _.reduce(result.dependencies, (soFar, dep) => {
-            soFar += `${dep.name} `
-            return soFar
-          }, '')
-          return execAsync(`npm install --no-save ${dependencies}`, { cwd: path })
-        }
-      }).then((result) => {
-        log('Writing temp configuration')
-        return writeFileAsync(join(path, 'versionist.tmp.js'), result.configuration)
-      }).then(() => {
-        return true
-      })
-    }
-    log('repo.yml: type does not match a declared preset')
+  return accessAsync(join(path, 'versionist.conf.js'))
+  .then(() => {
+    log('Found existing configuration')
     return false
+  })
+  .catch(() => {
+    return readFileAsync(join(path, 'repo.yml'), 'utf8')
+    .then((configFile) => {
+      const config = YAML.safeLoad(configFile)
+      if (!config.type) {
+        // Throw error here, will be caught and proceed with installConfigDependencies
+        throw new Error('No repo.type')
+      }
+      const normalisedType = remapTypes(normaliseConfigType(config.type))
+      log(`Versioning for type: ${normalisedType}`)
+      if (configOverrides[normalisedType]) {
+        if (config.upstream) {
+          config.upstream = extractUpstreamInfo(config.upstream)
+        }
+        return Promise.resolve(configOverrides[normalisedType].getConfig(config))
+        .tap((result) => {
+          log('Installing injected dependencies')
+          log(result.dependencies)
+          if (_.isArray(result.dependencies) && !_.isEmpty(result.dependencies)) {
+            const dependencies = _.reduce(result.dependencies, (soFar, dep) => {
+              soFar += `${dep.name} `
+              return soFar
+            }, '')
+            return execAsync(`npm install --no-save ${dependencies}`, { cwd: path })
+          }
+        }).then((result) => {
+          log('Writing temp configuration')
+          return writeFileAsync(join(path, 'versionist.tmp.js'), result.configuration)
+        }).then(() => {
+          return true
+        })
+      }
+      log('repo.yml: type does not match a declared preset')
+      return false
+    })
   })
 }
 


### PR DESCRIPTION
When configuring a repo with a generic type we create a temporary config
file for versionist from this template:
https://github.com/balena-io/balena-versionist/blob/master/lib/repo-type-mappings/generic/versionist.conf.js
This prevents the repo to set it's own custom `versionist.conf.js` in
case it needs to modify behavior.

This commit skips using the preset config when a versionist config is
detected in the repo root.

Change-type: minor
Signed-off-by: Robert Günzler <robertg@balena.io>